### PR TITLE
Release v1.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.31)
 project(
   datelib
-  VERSION 1.0.4
+  VERSION 1.0.5
   LANGUAGES CXX)
 
 # Set C++ standard using target properties (applied to all targets via CMAKE_CXX_*)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.organization=datelib
 
 # Project metadata
 sonar.projectName=datelib
-sonar.projectVersion=1.0.4
+sonar.projectVersion=1.0.5
 
 # Source code location
 sonar.sources=src,include


### PR DESCRIPTION
Automated version bump to 1.0.5 (patch release)

This PR bumps the version from 1.0.4 to 1.0.5 in:
- CMakeLists.txt
- sonar-project.properties (if present)

After merging, the release will be automatically published by the release-publish workflow.